### PR TITLE
updated node stats API call to support ES 1.x

### DIFF
--- a/es2graphite.py
+++ b/es2graphite.py
@@ -124,7 +124,7 @@ def send_to_graphite(metrics):
  
 def get_metrics():
     dt = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-    node_stats_url = 'http://%s/_cluster/nodes/stats?all=true' % get_es_host()
+    node_stats_url = 'http://%s/_nodes/stats?all=true' % get_es_host()
     log('%s: GET %s' % (dt, node_stats_url))
     node_stats_data = urllib2.urlopen(node_stats_url).read()
     node_stats = json.loads(node_stats_data)


### PR DESCRIPTION
In version 1.0 a breaking change was introduced to the node stats portion of the cluster apis. 

What was previously `ES_HOST/_cluster/nodes/stats?all=true` is now `ES_HOST/_nodes/stats?all=true`

0.9x - http://www.elasticsearch.org/guide/en/elasticsearch/reference/0.90/cluster-nodes-stats.html

1.x - http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html

@mattweber 