### PR TITLE
Fixed call to _stats to restrict the _stats output

### DIFF
--- a/es2graphite.py
+++ b/es2graphite.py
@@ -180,7 +180,7 @@ def get_metrics():
     indices_stats_url = 'http://%s/_stats?all=true' % get_es_host()
     if args.shard_stats:
         indices_stats_url = '%s&level=shards' % indices_stats_url
-    elif args.health-level == 'cluster':
+    elif args.health_level == 'cluster':
         indices_stats_url = '%s&level=cluster' % indices_stats_url
     log('%s: GET %s' % (dt, indices_stats_url))
     indices_stats_data = urllib2.urlopen(indices_stats_url).read()

--- a/es2graphite.py
+++ b/es2graphite.py
@@ -180,6 +180,8 @@ def get_metrics():
     indices_stats_url = 'http://%s/_stats?all=true' % get_es_host()
     if args.shard_stats:
         indices_stats_url = '%s&level=shards' % indices_stats_url
+    elif args.health-level == 'cluster':
+        indices_stats_url = '%s&level=cluster' % indices_stats_url
     log('%s: GET %s' % (dt, indices_stats_url))
     indices_stats_data = urllib2.urlopen(indices_stats_url).read()
     indices_stats = json.loads(indices_stats_data)
@@ -231,4 +233,3 @@ if __name__ == '__main__':
             time.sleep(args.interval)
         except Exception, e:
             logging.error(urllib.quote_plus(traceback.format_exc()))
-            sys.exit(1)

--- a/es2graphite.py
+++ b/es2graphite.py
@@ -87,7 +87,8 @@ def process_indices_status(prefix, status):
 def process_indices_stats(prefix, stats):
     metrics = []
     process_section(int(time.time()), metrics, (prefix, CLUSTER_NAME, 'indices', '_all'), stats['_all'])
-    process_section(int(time.time()), metrics, (prefix, CLUSTER_NAME, 'indices'), stats['indices'])
+    if args.health_level != 'cluster':
+        process_section(int(time.time()), metrics, (prefix, CLUSTER_NAME, 'indices'), stats['indices'])
     return metrics
     
 def process_segments_status(prefix, status):


### PR DESCRIPTION
* Updated call to _stats to restrict the output based on if you are choosing indices, shards or cluster
* Removed sys.exit(1) on global Exception catch. This will allow us to catch and log all exceptions without exiting the application loop. (With sys.exit(1) in, restarting the Graphite Concentrator when this tried to send would result in the application exiting.)
* Resolved an exception experienced when using cluster level health-levels where the process_indices_stats function would failed because it was attempting to access a key that does not exist.
