### PR TITLE
Corrected bad spacing for file_handler reference.

### DIFF
--- a/es2graphite.py
+++ b/es2graphite.py
@@ -280,8 +280,8 @@ if __name__ == '__main__':
                                                             maxBytes=100000000, 
                                                             backupCount=5)
         root_logger.addHandler(file_handler)
+        file_handler.setFormatter(logFormatter)
 
-    file_handler.setFormatter(logFormatter)
     root_logger.setLevel(loglevel[args.log_level])
 
     while True:


### PR DESCRIPTION
file_handler setFormatter is not spaced into the correct if block. This breaks es2graphite and prevents it from running.