### PR TITLE
New Features, code cleanup and loop timing improvement

### DIFF
--- a/es2graphite.py
+++ b/es2graphite.py
@@ -33,7 +33,7 @@ def timeit(method):
         ts = time.time()
         result = method(*args, **kw)
         te = time.time()
-        logging.info( '%r %2.2f sec' % \
+        logging.debug( '%r %2.2f sec' % \
               (method.__name__, te-ts))
         return result
     return timed


### PR DESCRIPTION
- Removed the process_node_stats code. This was due to a lot of
  duplicate data and the fact that most of the data stored in that
  branch was static data or text.
- Added time tracking for functions. This allows the ability to know
  exactly how long various functions take to run. Important for
  improving performance of the code.
- Updated the timing code for the loop. It now does a time check every
  second to see if it has rotated into a new minute. This prevents a
  fast loop from saturating a CPU and improves the submission of data to
  graphite, removing the time drift caused by using a time.sleep(60).
- Added processing of Thread_pool stats. This is importable for knowing
  if your cluster is falling behind in trying to index data being sent
  to it. I used this data to be able to identify a backup happening due to
  various default throttling settings in Elasticsearch.
- Added process_cluster_health to address missing data caused by the removal
  of process_node_stats.
- Added a -s/--silent command line options for disabling all output from
  es2graphite outside of sending metrics. (This was added to address
  issues when deploying es2graphite on Mesosphere in docker where the
  logging to file and stdout was causing dis saturation on the Mesos
  Nodes.
- Changed the timeit decorator to log into debug instead of info.
