### PR TITLE
Honor the interval parameter

### DIFF
--- a/es2graphite.py
+++ b/es2graphite.py
@@ -13,7 +13,7 @@ import socket
 import urllib
 import urllib2
 import argparse
-from datetime import datetime
+from datetime import datetime, timedelta
 
 NODES = {}
 CLUSTER_NAME = ''
@@ -329,9 +329,9 @@ if __name__ == '__main__':
                 sys.exit()
             else:
                 get_metrics()
-                completion_minute = datetime.now().minute
-                while datetime.now().minute == completion_minute:
-                    logging.debug('Waiting to run.. (' + str(completion_minute) + ')')
+                next_run_time = datetime.now() + timedelta(seconds=args.interval)
+                while datetime.now() < next_run_time:
+                    logging.debug('Waiting to run next at ' + str(next_run_time))
                     time.sleep(1)
         except Exception, e:
             logging.error(urllib.quote_plus(traceback.format_exc()))


### PR DESCRIPTION
This change will use the --interval (-i) parameter supplied on the
command line to delay the execution of the next metrics retrieval.

Previously, the interval was hard-coded for 1 minute (60 secs).

It's probably not a good idea to set the interval to less than
10 seconds. Retrieving metrics will take about this long and
graphite has a default resolution of 10 seconds.
