### PR TITLE
Fix indices_stats_url for ElasticSearch 5.0

### DIFF
--- a/es2graphite.py
+++ b/es2graphite.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 import re
 import sys

--- a/es2graphite.py
+++ b/es2graphite.py
@@ -265,7 +265,7 @@ def get_metrics():
     thread_pool_metrics = process_thread_pool(args.prefix, thread_pool, cluster_health['cluster_name'])
     submit_to_graphite(thread_pool_metrics)
 
-    indices_stats_url = 'http://%s/_stats?all=true' % get_es_host()
+    indices_stats_url = 'http://%s/_stats' % get_es_host()
     if args.shard_stats:
         indices_stats_url = '%s&level=shards' % indices_stats_url
     elif args.health_level == 'cluster':


### PR DESCRIPTION
Fixes broken HTTP GET for index statistics.

Should be backwards compatible because the all=true parameter has not been used by ElasticSearch for a long time.
    
See: https://github.com/elastic/elasticsearch/issues/21410